### PR TITLE
Changed BaseSimulation:start to log grid to verbose instead of info

### DIFF
--- a/meltingpot/lua/modules/base_simulation.lua
+++ b/meltingpot/lua/modules/base_simulation.lua
@@ -429,7 +429,7 @@ function BaseSimulation:start(grid)
     end
   end
   self:_avatarStart(grid)
-  log.info("grid\n" .. tostring(grid))
+  log.v("grid\n" .. tostring(grid))
 end
 
 --[[ End of starting callbacks ]]


### PR DESCRIPTION
Per #19, changes grid to log to log.v instead of log.info.