### PR TITLE
Issue 25: Extend rllib examples to save, load, and render bots

### DIFF
--- a/examples/rllib/utils.py
+++ b/examples/rllib/utils.py
@@ -26,8 +26,7 @@ from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 import tree
 
 from meltingpot.python import substrate
-from meltingpot.python.bot import Policy
-from meltingpot.python.bot import State
+from meltingpot.python import bot
 
 PLAYER_STR_FORMAT = 'player_{index}'
 
@@ -132,7 +131,7 @@ def env_creator(env_config):
   return env
 
 
-class RayModelPolicy(Policy):
+class RayModelPolicy(bot.Policy):
   """Policy wrapping an rllib model for inference.
 
   Note: Currently only supports a single input, batching is not enabled
@@ -152,7 +151,7 @@ class RayModelPolicy(Policy):
     self._policy_id = policy_id
 
   def step(self, timestep: dm_env.TimeStep,
-           prev_state: State) -> Tuple[int, State]:
+           prev_state: bot.State) -> Tuple[int, bot.State]:
     """See base class."""
     observations = {
         key: value
@@ -170,7 +169,7 @@ class RayModelPolicy(Policy):
     self._prev_action = action
     return action, state
 
-  def initial_state(self) -> State:
+  def initial_state(self) -> bot.State:
     """See base class."""
     self._prev_action = 0
     return self._model.get_policy(self._policy_id).get_initial_state()

--- a/examples/rllib/view_models.py
+++ b/examples/rllib/view_models.py
@@ -1,0 +1,100 @@
+# Copyright 2020 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Runs the bots trained in self_play_train.py and renders in pygame.
+You must provide experiment_state, expected to be
+~/ray_results/PPO/experiment_state_YOUR_RUN_ID.json
+"""
+
+import dm_env
+from dmlab2d.ui_renderer import pygame
+import numpy as np
+from ray.rllib.agents.registry import get_trainer_class
+from ray.tune.analysis.experiment_analysis import ExperimentAnalysis
+from ray.tune.registry import register_env
+
+from examples.rllib.utils import env_creator
+from examples.rllib.utils import RayModelPolicy
+
+
+def main():
+  # This will load the last training run created by self_play_train.py.
+  # If you want to use a specific run, update experiment_state path.
+  # The expected path is "~/ray_results/PPO/experiment_state-DATETIME.json"
+  experiment_state = "~/ray_results/PPO"
+
+  agent_algorithm = "PPO"
+  substrate_name = "clean_up"
+
+  register_env("meltingpot", env_creator)
+
+  experiment = ExperimentAnalysis(
+      experiment_state,
+      default_metric="episode_reward_mean",
+      default_mode="max")
+
+  config = experiment.best_config
+  checkpoint_path = experiment.best_checkpoint
+
+  trainer = get_trainer_class(agent_algorithm)(config=config)
+  trainer.restore(checkpoint_path)
+
+  # Create a new environment to visualise
+  env = env_creator(config["env_config"])._env
+
+  num_bots = config["env_config"]["num_players"]
+  bots = [RayModelPolicy(trainer, "av")] * num_bots
+
+  timestep = env.reset()
+  states = [bot.initial_state() for bot in bots]
+  actions = [0] * len(bots)
+
+  # Configure the pygame display
+  scale = 4
+  fps = 5
+
+  pygame.init()
+  clock = pygame.time.Clock()
+  pygame.display.set_caption('DM Lab2d')
+  obs_spec = env.observation_spec()
+  shape = obs_spec[0]['WORLD.RGB'].shape
+  game_display = pygame.display.set_mode(
+      (int(shape[1] * scale), int(shape[0] * scale)))
+
+  for _ in range(config["horizon"]):
+    obs = timestep.observation[0]['WORLD.RGB']
+    obs = np.transpose(obs, (1, 0, 2))
+    surface = pygame.surfarray.make_surface(obs)
+    rect = surface.get_rect()
+    surf = pygame.transform.scale(surface,
+                                  (int(rect[2] * scale), int(rect[3] * scale)))
+
+    game_display.blit(surf, dest=(0, 0))
+    pygame.display.update()
+    clock.tick(fps)
+
+    for i, bot in enumerate(bots):
+      timestep_bot = dm_env.TimeStep(
+          step_type=timestep.step_type,
+          reward=timestep.reward[i],
+          discount=timestep.discount,
+          observation=timestep.observation[i])
+
+      actions[i], states[i] = bot.step(timestep_bot, states[i])
+
+    timestep = env.step(actions)
+
+
+if __name__ == "__main__":
+  main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,7 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "google"
+src_paths = ["meltingpot", "examples"]


### PR DESCRIPTION
This patch uses ray.tune to save the trained models from self_play_train.py and allows you to view their behaviour in a pygame instance by running view_model.py.

Disclaimer:
I am only ~1 month familiar with RLLib and Melting Pot.

Note:
It is unfortunate that I needed to pass RayModelPolicy a full rllib.agents.trainer.Trainer instance, rather than just a rllib.policy.policy.Policy. This is because rllib.agents.trainer does some pre-processing of the inputs before forwarding to the policy (see lines 1452-1457 in Ray 1.11.0).

Also, although against the spirit of the library, I wanted to demonstrate that the RayModelPolicy could play against the PermissiveModelPolicy. I was not able to do this however, as replacing some of the bots in view_model.py with bots created via:
`bot_factory.build(bot_factory.get_config("ah3gs_bot_finding_berry_two_the_most_tasty_0"))`
Resulted in errors about the observations that they received. Therefore rllib bots and existing meltingpots cannot be mixed at the moment.

Finally, would you be open to answering some questions I have about use of this repo? I intend to make some modifications to meltingpot for my experiments and I would appreciate it if I could run my proposed changes by you.
