### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT="3.9"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# Install pytest
+RUN pip install pytest
+
+# Install lab2d
+RUN pip install https://github.com/deepmind/lab2d/releases/download/release_candidate_2021-07-13/dmlab2d-1.0-cp39-cp39-manylinux_2_31_x86_64.whl
+
+# Download assets
+ADD https://storage.googleapis.com/dm-meltingpot/meltingpot-assets-1.0.0.tar.gz /workspaces/meltingpot/meltingpot/
+
+# Set Python path
+ENV PYTHONPATH="/workspaces/meltingpot"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,49 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/python-3
+{
+    "name": "Meltingpot (Python 3)",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "..",
+        "args": {
+            // Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+            // Append -bullseye or -buster to pin to an OS version.
+            // Use -bullseye variants on local on arm64/Apple Silicon.
+            "VARIANT": "3.9"
+        }
+    },
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": true,
+                "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+                "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+                "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+                "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+                "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+                "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+                "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+                "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+            },
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    },
+    // Run the install script on create
+    "postCreateCommand": "pip install .[rllib] .[pettingzoo]",
+    // Vscode only user fix - see https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode",
+    "runArgs": [
+        // Increase SHM sufficiently for RlLib. Note you can increase this further for 
+        // performance gains (recommended to be at least 30% of RAM on large machines).
+        "--shm-size=6g"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,19 @@ documentation.
 ## Installation
 
 Melting Pot is built on top of
-[DeepMind Lab2D](https://github.com/deepmind/lab2d). The installation steps are
+[DeepMind Lab2D](https://github.com/deepmind/lab2d). 
+
+### Devcontainer
+
+This project includes a pre-configured development environment ([devcontainer](https://containers.dev)).
+
+You can launch a working development environment with one click, using e.g. [Github
+Codespaces](https://github.com/features/codespaces) or the [VSCode
+Containers](https://code.visualstudio.com/docs/remote/containers-tutorial) extension.
+
+### Manual install
+
+The installation steps are
 as follows (see [`install.sh`](https://github.com/deepmind/meltingpot/blob/main/install.sh)
 for an example installation script):
 


### PR DESCRIPTION
Enables one-click launching of devcontainers (e.g. with [GitHub Codespaces](https://github.com/features/codespaces) or [VSCode remote containers](https://code.visualstudio.com/docs/remote/containers)), with all dependencies automatically installed.

I'm currently using this personally to speed up working with meltingpot, but figured others may find it helpful given how popular devcontainers are becoming (especially Codespaces)?

It should also help reduce support requests, for setup related issues.