### PR TITLE
Add CUDA support to Docker/Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,34 @@
-# Python 3.9-bullseye variant from https://github.com/microsoft/vscode-dev-containers/python-3/.devcontainer/base.Dockerfile
-# Note bullseye version is multi-architecture (supports arm64)
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.9-bullseye@sha256:29ca94ddf0f254cb36e311ae59520c4dee33a35de7c0b2f1bd7b91650d368ee0
+# Use Nvidia Ubuntu 20 base (includes CUDA if a supported GPU is present)
+# https://hub.docker.com/r/nvidia/cuda
+FROM nvidia/cuda:11.2.1-cudnn8-devel-ubuntu20.04@sha256:cf6c4023f17d22d5f37b38b7e22f0aef7e9f3183aa7ce5743c5e248670be86a1
 
-# Install pytest
-RUN pip install pytest
+# Install dependencies
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+  build-essential \
+  curl \
+  ffmpeg \
+  git \
+  python3.9 \
+  python3.9-dev \
+  python3.9-distutils \
+  rsync
+
+# Install pip (we need the latest version not the standard Ubuntu version, to
+# support modern wheels)
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.9 get-pip.py
+
+# Set python aliases
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+
+# Install python dev dependencies
+RUN pip install \
+  jedi \
+  pytest \
+  pylance \
+  toml \
+  yapf
 
 # Install lab2d (appropriate version for architecture)
 RUN if [ "$(uname -m)" != 'x86_64' ]; then \
@@ -16,7 +41,9 @@ RUN if [ "$(uname -m)" != 'x86_64' ]; then \
   fi
 
 # Download assets
-ADD https://storage.googleapis.com/dm-meltingpot/meltingpot-assets-1.0.0.tar.gz /workspaces/meltingpot/meltingpot/
+RUN mkdir -p /workspaces/meltingpot/meltingpot && \
+  curl -SL https://storage.googleapis.com/dm-meltingpot/meltingpot-assets-1.0.0.tar.gz \
+  | tar -xz --directory=/workspaces/meltingpot/meltingpot
 
 # Set Python path
 ENV PYTHONPATH="/workspaces/meltingpot"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/python-3
+// For format details, see https://aka.ms/devcontainer.json
 {
     "name": "Meltingpot (Python 3)",
     "build": {
@@ -11,32 +10,23 @@
         // Configure properties specific to VS Code.
         "vscode": {
             "settings": {
-                "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "python.linting.enabled": true,
-                "python.linting.pylintEnabled": true,
                 "python.formatting.provider": "yapf",
-                "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-                "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-                "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-                "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-                "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-                "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-                "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+                "python.formatting.yapfPath": "yapf"
             },
             "extensions": [
                 "ms-python.python",
                 "ms-python.vscode-pylance",
-                "ms-azuretools.vscode-docker"
+                "ms-azuretools.vscode-docker",
+                "donjayamanne.githistory"
             ]
         }
     },
     // Run the install script on create
     "postCreateCommand": "pip install .[rllib] .[pettingzoo]",
-    // Vscode only user fix - see https://aka.ms/vscode-remote/containers/non-root.
-    "remoteUser": "vscode",
     "runArgs": [
         // Increase SHM sufficiently for RlLib. Note you can increase this further for 
         // performance gains (recommended to be at least 30% of RAM on large machines).
-        "--shm-size=6g"
+        "--shm-size=6gb"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,16 @@ This project includes a pre-configured development environment ([devcontainer](h
 
 You can launch a working development environment with one click, using e.g. [Github
 Codespaces](https://github.com/features/codespaces) or the [VSCode
-Containers](https://code.visualstudio.com/docs/remote/containers-tutorial) extension.
+Containers](https://code.visualstudio.com/docs/remote/containers-tutorial)
+extension.
+
+#### CUDA support
+
+To enable CUDA support (required for GPU training), make sure you have the
+[nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+package installed, and then run Docker with the `---gpus all` flag enabled. Note
+that for GitHub Codespaces this isn't necessary, as it's done for you
+automatically.
 
 ### Manual install
 


### PR DESCRIPTION
This utilises the base Nvidia Ubuntu image, which is the only way to automatically install CUDA and cuDNN with Docker. The approach is similar to other popular libraries e.g. TensorFlow - https://www.tensorflow.org/install/docker . The image also works on machines without NVidia GPUs, essentially just providing a base Ubuntu image in that case.