### PR TITLE
Pin dependencies for RLlib examples to avoid incompatibilities

### DIFF
--- a/examples/requirements.in
+++ b/examples/requirements.in
@@ -6,7 +6,14 @@ dmlab2d
 gymnasium
 matplotlib
 ml_collections
-numpy
+numpy==1.24.4
 ray[rllib,default]==2.5.0
+scipy==1.10.1
+jax==0.4.13
+jaxlib==0.4.13
+chex==0.1.7
+typing_extensions==4.5.0
 supersuit>=3.7.2
 torch
+tensorflow==2.13.1
+tensorflow-probability==0.21.0


### PR DESCRIPTION
### Summary

This PR updates `examples/requirements.in` to pin dependency versions that are
known to work with the RLlib example scripts.

Without these pins, installing the example dependencies on modern Python
environments often results in runtime errors due to incompatibilities between
Ray 2.5, NumPy 2.x, SciPy, TensorFlow, JAX, and related libraries.

The updated requirements reflect a tested, working configuration and improve
reproducibility for users running the RLlib examples.

---

### Motivation

Several users (see #299) have reported failures when installing and running the
example training scripts using the current `examples/requirements.in`. The file
does not specify version constraints for a number of critical dependencies,
leading to incompatible combinations being installed by default.

This change makes the dependency expectations explicit and aligns the
requirements with versions that successfully run the example training code.

---

### Changes

- Pin NumPy, SciPy, Ray, TensorFlow, TensorFlow Probability, JAX, Chex, and
  typing_extensions to compatible versions
- Add TensorFlow dependencies required for loading pretrained Melting Pot bots
- Keep the scope limited to example dependencies only (no core code changes)

---

### Testing

- Installed dependencies from `examples/requirements.in` in a clean virtual
  environment
- Verified core imports (Ray, TensorFlow, JAX, Melting Pot)
- Successfully launched the RLlib self-play example
  (`python -m examples.rllib.self_play_train`) without runtime errors

---

This change does not affect the core Melting Pot library and only impacts the
example setup.
