### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,89 @@
+name: install
+
+inputs:
+  python-version:
+    description: Python version
+    required: false
+    default: ''
+    type: string
+
+outputs:
+  key:
+    description: Cache key that identifies the installation
+    value: ${{ steps.cache-key.outputs.key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      id: setup-python
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Get cache key
+      id: cache-key
+      shell: bash
+      env:
+        PYTHON_VERSION: ${{ steps.setup-python.outputs.python-version }}
+      run: |
+        if [ "${RUNNER_OS}" = 'macOS' ]; then
+          readonly name="$(sw_vers -productName)"
+          readonly version="$(sw_vers -productVersion)"
+        elif [ "${RUNNER_OS}" = 'Linux' ]; then
+          readonly name="$(lsb_release -i -s)"
+          readonly version="$(lsb_release -r -s)"
+        else
+          exit 1
+        fi
+        echo "key=${name}-${version}-py${PYTHON_VERSION}-${{ hashFiles('requirements.txt') }}" >> $GITHUB_OUTPUT
+
+    - name: Restore installation
+      id: restore
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      with:
+        path: |
+          meltingpot/assets
+          venv
+        key: install-${{ steps.cache-key.outputs.key }}
+
+    - name: Create venv
+      if: steps.restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        python -m venv venv
+
+    - name: Activate venv
+      shell: bash
+      run: |
+        echo "${PWD}/venv/bin" >> $GITHUB_PATH
+
+    - name: Install
+      if: steps.restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        ./bin/install.sh
+
+    - name: Show installation
+      shell: bash
+      run: |
+        which python
+        python --version
+        which pip
+        pip --version
+        which pylint
+        pylint --version
+        which pytest
+        pytest --version
+        which pytype
+        pytype --version
+        pip list
+
+    - name: Save installation
+      if: steps.restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+      with:
+        path:  |
+          meltingpot/assets
+          venv
+        key: ${{ steps.restore.outputs.cache-primary-key }}

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Set up Python ${{ inputs.python-version }}
       id: setup-python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,62 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '36 13 * * 4'
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@fe4161a26a8629af62121b670040955b330f9af2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@fe4161a26a8629af62121b670040955b330f9af2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,116 @@
+# A workflow to publish releases to PyPi and TestPyPi.
+
+name: pypi-publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build:
+    name: Build
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout Melting Pot
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+      - name: Show Python setup
+        run: |
+          python --version
+          pip list
+      - name: Build distribution
+        run: |
+          python setup.py sdist
+          # Workaround old setuptools not normalizing name in sdist.
+          for OLD in ./dist/dm-meltingpot-*; do
+             NEW="$(echo "$OLD" | sed s/dm-meltingpot/dm_meltingpot/)"
+             mv "$OLD" "$NEW"
+          done
+          ls dist/*
+      - name: Save artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: dist
+          path: ./dist
+          retention-days: 1
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ${{ matrix.os }}
+    env:
+      SYSTEM_VERSION_COMPAT: 0  # See https://github.com/actions/setup-python/issues/279.
+    timeout-minutes: 180
+    strategy:
+      fail-fast: ${{ github.event_name == 'release' }}
+      matrix:
+        os:
+          - macos-14
+          - macos-15
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        python-version:
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+    steps:
+      - name: Load artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: dist
+          path: ./dist
+      - name: Set up Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade setuptools
+      - name: Install source distribution
+        run: |
+          pip install dist/*.tar.gz
+          pip list
+          pip check
+      - name: Test source distribution
+        run: |
+          pip install pytest-xdist
+          pytest -n auto --pyargs meltingpot
+
+  publish:
+    name: Publish
+    needs: [build, test]
+    if: always() && needs.build.result == 'success' && needs.test.result != 'failure'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dm-meltingpot
+    permissions:
+      id-token: write
+    timeout-minutes: 10
+    steps:
+      - name: Load artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: dist
+          path: ./dist
+      - name: Publish to TestPyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          attestations: false
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+      - name: Publish to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          attestations: false
+          verbose: true

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout Melting Pot
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Show Python setup
         run: |
           python --version
@@ -32,7 +32,7 @@ jobs:
           done
           ls dist/*
       - name: Save artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: dist
           path: ./dist
@@ -62,12 +62,12 @@ jobs:
           - '3.14'
     steps:
       - name: Load artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: dist
           path: ./dist
       - name: Set up Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Load artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: dist
           path: ./dist

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -1,0 +1,77 @@
+# Continuous integration tests.
+
+name: pypi-test
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"  # Every Monday at 2am.
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/pypi-test.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/pypi-test.yml'
+  workflow_run:
+    workflows:
+      - pypi-publish
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to test'
+        type: string
+        default: ''
+
+permissions: read-all
+
+jobs:
+  pypi-test:
+    name: Test PyPI Distribution
+    if: ${{ github.event.workflow_run.conclusion != 'failure' }}
+    runs-on: ${{ matrix.os }}
+    env:
+      SYSTEM_VERSION_COMPAT: 0  # See https://github.com/actions/setup-python/issues/279.
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-14
+          - macos-15
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        python-version:
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+
+    steps:
+      - name: Set up Python ${{ matrix.python_version }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade setuptools
+
+      - name: Install from PyPI
+        run: |
+          VERSION="${{github.event.inputs.version}}"
+          pip install "dm-meltingpot${VERSION:+==$VERSION}"
+          pip list
+          pip check
+
+      - name: Test installation
+        run: |
+          pip install pytest-xdist
+          pytest -n auto --pyargs meltingpot

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -1,0 +1,62 @@
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: '17 10 * * 0'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge. (Upcoming feature)
+      id-token: write
+      # Needs for private repositories.
+      contents: read
+      actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) Read-only PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecards on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,0 +1,58 @@
+name: test-examples
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/actions/install/action.yml'
+      - '.github/workflows/test-examples.yml'
+      - '.pylintrc'
+      - 'bin/install.sh'
+      - 'examples/**'
+      - 'meltingpot/**'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'setup.py'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/actions/install/action.yml'
+      - '.github/workflows/test-examples.yml'
+      - '.pylintrc'
+      - '.python-version'
+      - 'bin/install.sh'
+      - 'examples/**'
+      - 'meltingpot/**'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'setup.py'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  test-examples:
+    name: Test examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout Melting Pot
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+
+      - name: Install Melting Pot
+        uses: ./.github/actions/install
+
+      - name: Test examples
+        run: pytest examples
+
+      - name: Lint examples
+        run: pylint --errors-only examples
+
+      - name: Typecheck examples
+        run: pytype examples

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout Melting Pot
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Melting Pot
         uses: ./.github/actions/install

--- a/.github/workflows/test-meltingpot.yml
+++ b/.github/workflows/test-meltingpot.yml
@@ -1,0 +1,55 @@
+name: test-meltingpot
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/actions/install/action.yml'
+      - '.github/workflows/test-meltingpot.yml'
+      - '.pylintrc'
+      - 'bin/install.sh'
+      - 'meltingpot/**'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'setup.py'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/actions/install/action.yml'
+      - '.github/workflows/test-meltingpot.yml'
+      - '.pylintrc'
+      - '.python-version'
+      - 'bin/install.sh'
+      - 'meltingpot/**'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - 'setup.py'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  test-meltingpot:
+    name: Test Melting Pot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Melting Pot
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+
+      - name: Install Melting Pot
+        uses: ./.github/actions/install
+
+      - name: Test Melting Pot
+        run: pytest meltingpot
+
+      - name: Lint Melting Pot
+        run: pylint --errors-only meltingpot
+
+      - name: Typecheck Melting Pot
+        run: pytype meltingpot

--- a/.github/workflows/test-meltingpot.yml
+++ b/.github/workflows/test-meltingpot.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Melting Pot
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Melting Pot
         uses: ./.github/actions/install


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3, actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4, actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53, actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548, actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830, actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache/restore` | [`0057852`](https://github.com/actions/cache/restore/commit/0057852bfaa89a56745cba8c7296529d2fc39830) | [`cdf6c1f`](https://github.com/actions/cache/restore/commit/cdf6c1fa76f9f475f3d7449005a359c84ca0f306) | [Release](https://github.com/actions/cache/restore/releases/tag/v5) | action.yml |
| `actions/cache/save` | [`0057852`](https://github.com/actions/cache/save/commit/0057852bfaa89a56745cba8c7296529d2fc39830) | [`cdf6c1f`](https://github.com/actions/cache/save/commit/cdf6c1fa76f9f475f3d7449005a359c84ca0f306) | [Release](https://github.com/actions/cache/save/releases/tag/v5) | action.yml |
| `actions/checkout` | [`1af3b93`](https://github.com/actions/checkout/commit/1af3b93b6815bc44a9784bd300feb67ff0d1eeb3) | [`de0fac2`](https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd) | [Release](https://github.com/actions/checkout/releases/tag/v6) | codeql-analysis.yml, pypi-publish.yml, scorecards-analysis.yml, test-examples.yml, test-meltingpot.yml |
| `actions/download-artifact` | [`018cc2c`](https://github.com/actions/download-artifact/commit/018cc2cf5baa6db3ef3c5f8a56943fffe632ef53) | [`3e5f45b`](https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | pypi-publish.yml |
| `actions/setup-python` | [`83679a8`](https://github.com/actions/setup-python/commit/83679a892e2d95755f2dac6acb0bfd1e9ac5d548) | [`a309ff8`](https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | action.yml, pypi-publish.yml, pypi-test.yml |
| `actions/upload-artifact` | [`330a01c`](https://github.com/actions/upload-artifact/commit/330a01c490aca151604b8cf639adc76d48f6c5d4) | [`bbbca2d`](https://github.com/actions/upload-artifact/commit/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | pypi-publish.yml, scorecards-analysis.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
